### PR TITLE
thread safe duplicate check

### DIFF
--- a/server/src/main/kotlin/it/polito/wa2/group03/server/service/TicketingServiceStateful.kt
+++ b/server/src/main/kotlin/it/polito/wa2/group03/server/service/TicketingServiceStateful.kt
@@ -10,7 +10,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
 
 @Service
-class TicketingServiceStateful(@Value("\${jwt.key}") private val key: String) : TicketingServiceStateless(key) {
+class TicketingServiceStateful(@Value("\${jwt.key}") private val key: String): TicketingServiceStateless(key) {
 
     private var ticketQueue: Queue<String> = ConcurrentLinkedQueue()
     private val parser: JwtParser =
@@ -22,11 +22,15 @@ class TicketingServiceStateful(@Value("\${jwt.key}") private val key: String) : 
 
             val sub = this.getSub(ticket.token)
 
-            when (sub in ticketQueue){
+            when (sub in ticketQueue) {
                 true -> return ValidationResult.DUPLICATE
                 false -> ticketQueue.add(sub)
             }
 
+            /**
+             * once we are sure the ticket is not a duplicate
+             * we can process it as we would do for any other.
+             */
             return super.validateTicket(ticket)
 
         } catch (e: Exception) {


### PR DESCRIPTION
while I made the rest of the services implementation compliant to the kotlin interface approach and the specifications required for the project, the `main` branch is currently not thread safe.

the idea here is to use a `ConcurrentLinkedQueue` to make it as straightforward as possible. however I do not have experience with this type of queue, so I require reviews and maybe we could figure out some specific testing to make sure it's working as expected.